### PR TITLE
[MCLEAN-116] Use default Log interface

### DIFF
--- a/src/main/java/org/apache/maven/plugins/clean/CleanMojo.java
+++ b/src/main/java/org/apache/maven/plugins/clean/CleanMojo.java
@@ -186,8 +186,8 @@ public class CleanMojo extends AbstractMojo {
      * should usually reside on the same volume. The exact conditions are system dependant though, but if an atomic
      * move is not supported, the standard deletion mechanism will be used.
      *
-     * @since 3.2
      * @see #fast
+     * @since 3.2
      */
     @Parameter(property = "maven.clean.fastDir")
     private File fastDir;
@@ -199,8 +199,8 @@ public class CleanMojo extends AbstractMojo {
      * the actual file deletion should be started in the background when the session ends (this should only be used
      * when maven is embedded in a long running process).
      *
-     * @since 3.2
      * @see #fast
+     * @since 3.2
      */
     @Parameter(property = "maven.clean.fastMode", defaultValue = FAST_MODE_BACKGROUND)
     private String fastMode;

--- a/src/test/java/org/apache/maven/plugins/clean/CleanMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/clean/CleanMojoTest.java
@@ -30,6 +30,7 @@ import java.nio.file.Paths;
 import java.util.Collections;
 
 import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.logging.SystemStreamLog;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 
 import static org.apache.commons.io.FileUtils.copyDirectory;
@@ -273,6 +274,7 @@ public class CleanMojoTest extends AbstractMojoTestCase {
 
     /**
      * Test the followLink option with windows junctions
+     *
      * @throws Exception
      */
     public void testFollowLinksWithWindowsJunction() throws Exception {
@@ -298,6 +300,7 @@ public class CleanMojoTest extends AbstractMojoTestCase {
 
     /**
      * Test the followLink option with sym link
+     *
      * @throws Exception
      */
     public void testFollowLinksWithSymLinkOnPosix() throws Exception {
@@ -315,13 +318,9 @@ public class CleanMojoTest extends AbstractMojoTestCase {
         });
     }
 
-    @FunctionalInterface
-    interface LinkCreator {
-        void createLink(Path link, Path target) throws Exception;
-    }
-
     private void testSymlink(LinkCreator linkCreator) throws Exception {
-        Cleaner cleaner = new Cleaner(null, null, false, null, null);
+        // We use the SystemStreamLog() as the AbstractMojo class, because from there the Log is always provided
+        Cleaner cleaner = new Cleaner(null, new SystemStreamLog(), false, null, null);
         Path testDir = Paths.get("target/test-classes/unit/test-dir").toAbsolutePath();
         Path dirWithLnk = testDir.resolve("dir");
         Path orgDir = testDir.resolve("org-dir");
@@ -370,5 +369,10 @@ public class CleanMojoTest extends AbstractMojoTestCase {
     private boolean checkEmpty(String dir) {
         File[] files = new File(dir).listFiles();
         return files == null || files.length == 0;
+    }
+
+    @FunctionalInterface
+    interface LinkCreator {
+        void createLink(Path link, Path target) throws Exception;
     }
 }


### PR DESCRIPTION
Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Make sure there is a [JIRA issue](https://issues.apache.org/jira/browse/MCLEAN) filed 
       for the change (usually before you start working on it).  Trivial changes like typos do not 
       require a JIRA issue.  Your pull request should address just this issue, without 
       pulling in other changes.
 - [ ] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Format the pull request title like `[MCLEAN-XXX] - Fixes bug in ApproximateQuantiles`,
       where you replace `MCLEAN-XXX` with the appropriate JIRA issue. Best practice
       is to use the JIRA issue title in the pull request title and in the first line of the 
       commit message.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.
 - [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).

If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)

 - [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

----------

Provided commit message for squashing

```
[MCLEAN-116] Use default Log interface
Submitted by: Matthias Bünger

The logging interface of the Cleaner class was not able to log exceptions in a suitable way.
So it was replaced by the default logging interface provided by the AbstractMojo class.

As the AbstractMojo always returns a log instance (therefore never null) the null checks were removed and the same Systemlogger was used in the tests.
```

As changes are more than 20 lines I will file the icla later the day. 
