### PR TITLE
[MCLEAN-110, MCLEAN-124, MCLEAN-126, ] Merge 3.x to 4.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,12 @@ under the License.
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>4.11.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-api-impl</artifactId>
       <version>${mavenVersion}</version>

--- a/src/it/dangling-symlinks/setup.groovy
+++ b/src/it/dangling-symlinks/setup.groovy
@@ -17,28 +17,24 @@
  * under the License.
  */
 
-import java.io.*;
 import java.nio.file.*;
-import java.util.*;
-import java.util.jar.*;
-import java.util.regex.*;
-import org.apache.maven.plugins.clean.*;
+import java.nio.file.attribute.*;
 
 try
 {
-    File targetDir = new File( basedir, "target" );
-    File link = new File( targetDir, "link" );
-    File target = new File( targetDir, "link-target.txt" );
+    Path targetDir = basedir.toPath().resolve( "target" );
+    Path link = targetDir.resolve( "link" );
+    Path target = targetDir.resolve( "link-target.txt" );
 
     System.out.println( "Creating symlink " + link + " -> " + target );
-    Files.createSymbolicLink( link.toPath(), target.toPath() );
-    if ( !link.exists() )
+    Files.createSymbolicLink( link, target, new FileAttribute[0] );
+    if ( !Files.exists( link, new LinkOption[0] ) )
     {
         System.out.println( "Platform does not support symlinks, skipping test." );
     }
 
     System.out.println( "Deleting symlink target " + target );
-    target.delete();
+    Files.delete( target );
 }
 catch( Exception ex )
 {

--- a/src/it/symlink-dont-follow/setup.groovy
+++ b/src/it/symlink-dont-follow/setup.groovy
@@ -17,12 +17,8 @@
  * under the License.
  */
 
-import java.io.*;
 import java.nio.file.*;
-import java.util.*;
-import java.util.jar.*;
-import java.util.regex.*;
-import org.apache.maven.plugins.clean.*;
+import java.nio.file.attribute.*;
 
 def pairs =
 [
@@ -34,13 +30,11 @@ def pairs =
 
 for ( pair : pairs )
 {
-    File target = new File( basedir, pair[0] );
-    File link = new File( basedir, pair[1] );
+    Path target = basedir.toPath().resolve( pair[0] );
+    Path link = basedir.toPath().resolve( pair[1] );
     println "Creating symlink " + link + " -> " + target;
-    Path targetPath = target.toPath();
-    Path linkPath = link.toPath();
-    Files.createSymbolicLink( linkPath, targetPath );
-    if ( !link.exists() )
+    Files.createSymbolicLink( link, target, new FileAttribute[0] );
+    if ( !Files.exists( link, new LinkOption[0] ) )
     {
         println "Platform does not support symlinks, skipping test.";
         return;

--- a/src/main/java/org/apache/maven/plugins/clean/CleanMojo.java
+++ b/src/main/java/org/apache/maven/plugins/clean/CleanMojo.java
@@ -188,7 +188,7 @@ public class CleanMojo implements org.apache.maven.api.plugin.Mojo {
      * <code>${maven.multiModuleProjectDirectory}/target/.clean</code> directory will be used.  If the
      * <code>${build.directory}</code> has been modified, you'll have to adjust this property explicitly.
      * In order for fast clean to work correctly, this directory and the various directories that will be deleted
-     * should usually reside on the same volume. The exact conditions are system dependant though, but if an atomic
+     * should usually reside on the same volume.  The exact conditions are system-dependent though, but if an atomic
      * move is not supported, the standard deletion mechanism will be used.
      *
      * @since 3.2
@@ -201,8 +201,8 @@ public class CleanMojo implements org.apache.maven.api.plugin.Mojo {
      * Mode to use when using fast clean.  Values are: <code>background</code> to start deletion immediately and
      * waiting for all files to be deleted when the session ends, <code>at-end</code> to indicate that the actual
      * deletion should be performed synchronously when the session ends, or <code>defer</code> to specify that
-     * the actual file deletion should be started in the background when the session ends (this should only be used
-     * when maven is embedded in a long running process).
+     * the actual file deletion should be started in the background when the session ends.  This should only be used
+     * when maven is embedded in a long-running process.
      *
      * @since 3.2
      * @see #fast

--- a/src/test/java/org/apache/maven/plugins/clean/CleanerTest.java
+++ b/src/test/java/org/apache/maven/plugins/clean/CleanerTest.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.plugins.clean;
+
+import java.io.IOException;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.DirectoryNotEmptyException;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.Set;
+
+import org.apache.maven.api.plugin.Log;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static java.nio.file.Files.createDirectory;
+import static java.nio.file.Files.createFile;
+import static java.nio.file.Files.exists;
+import static java.nio.file.Files.setPosixFilePermissions;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class CleanerTest {
+
+    private final Log log = mock();
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void deleteSucceedsDeeply(@TempDir Path tempDir) throws Exception {
+        final Path basedir = createDirectory(tempDir.resolve("target")).toRealPath();
+        final Path file = createFile(basedir.resolve("file"));
+        final Cleaner cleaner = new Cleaner(null, log, false, null, null);
+        cleaner.delete(basedir, null, false, true, false);
+        assertFalse(exists(basedir));
+        assertFalse(exists(file));
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void deleteFailsWithoutRetryWhenNoPermission(@TempDir Path tempDir) throws Exception {
+        when(log.isWarnEnabled()).thenReturn(TRUE);
+        final Path basedir = createDirectory(tempDir.resolve("target")).toRealPath();
+        createFile(basedir.resolve("file"));
+        // Remove the executable flag to prevent directory listing, which will result in a DirectoryNotEmptyException.
+        final Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("rw-rw-r--");
+        setPosixFilePermissions(basedir, permissions);
+        final Cleaner cleaner = new Cleaner(null, log, false, null, null);
+        final IOException exception =
+                assertThrows(IOException.class, () -> cleaner.delete(basedir, null, false, true, false));
+        verify(log, never()).warn(any(CharSequence.class), any(Throwable.class));
+        assertEquals("Failed to delete " + basedir, exception.getMessage());
+        // MCLEAN-124 Fixed on the 3.x branch: wrapper IOException has cause DirectoryNotEmptyException, the latter
+        // being the accurate reason of failure.
+        // On the 4.x branch it behaves differently: wrapper IOException has cause which is another IOException which
+        // has suppressed DirectoryNotEmptyException.
+        // So on 3.x one needed to get the cause to get the accurate reason of failure. Simple.
+        //        final DirectoryNotEmptyException cause =
+        //                assertInstanceOf(DirectoryNotEmptyException.class, exception.getCause());
+        // On 4.x, one now needs to get the suppressed exception from the cause for that. Slightly more complicated.
+        final DirectoryNotEmptyException suppressed = assertInstanceOf(
+                DirectoryNotEmptyException.class, exception.getCause().getSuppressed()[0]);
+        assertEquals(basedir.toString(), suppressed.getMessage());
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void deleteFailsAfterRetryWhenNoPermission(@TempDir Path tempDir) throws Exception {
+        final Path basedir = createDirectory(tempDir.resolve("target")).toRealPath();
+        createFile(basedir.resolve("file"));
+        // Remove the executable flag to prevent directory listing, which will result in a DirectoryNotEmptyException.
+        final Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("rw-rw-r--");
+        setPosixFilePermissions(basedir, permissions);
+        final Cleaner cleaner = new Cleaner(null, log, false, null, null);
+        final IOException exception =
+                assertThrows(IOException.class, () -> cleaner.delete(basedir, null, false, true, true));
+        assertEquals("Failed to delete " + basedir, exception.getMessage());
+        // MCLEAN-124 Similar different in 3.x versus 4.x behavior as explained above.
+        final DirectoryNotEmptyException suppressed = assertInstanceOf(
+                DirectoryNotEmptyException.class, exception.getCause().getSuppressed()[0]);
+        assertEquals(basedir.toString(), suppressed.getMessage());
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void deleteLogsWarningWithoutRetryWhenNoPermission(@TempDir Path tempDir) throws Exception {
+        when(log.isWarnEnabled()).thenReturn(TRUE);
+        final Path basedir = createDirectory(tempDir.resolve("target")).toRealPath();
+        final Path file = createFile(basedir.resolve("file"));
+        // Remove the writable flag to prevent deletion of the file, which will result in an AccessDeniedException.
+        final Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("r-xr-xr-x");
+        setPosixFilePermissions(basedir, permissions);
+        final Cleaner cleaner = new Cleaner(null, log, false, null, null);
+        assertDoesNotThrow(() -> cleaner.delete(basedir, null, false, false, false));
+        verify(log, times(2)).warn(any(CharSequence.class), any(Throwable.class));
+        InOrder inOrder = inOrder(log);
+        // MCLEAN-124 Similar different in 3.x versus 4.x behavior as explained above.
+        ArgumentCaptor<IOException> captor1 = ArgumentCaptor.forClass(IOException.class);
+        inOrder.verify(log).warn(eq("Failed to delete " + file), captor1.capture());
+        final AccessDeniedException cause1 =
+                assertInstanceOf(AccessDeniedException.class, captor1.getValue().getSuppressed()[0]);
+        assertEquals(file.toString(), cause1.getMessage());
+        ArgumentCaptor<IOException> captor2 = ArgumentCaptor.forClass(IOException.class);
+        inOrder.verify(log).warn(eq("Failed to delete " + basedir), captor2.capture());
+        final DirectoryNotEmptyException cause2 = assertInstanceOf(
+                DirectoryNotEmptyException.class, captor2.getValue().getSuppressed()[0]);
+        assertEquals(basedir.toString(), cause2.getMessage());
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void deleteDoesNotLogAnythingWhenNoPermissionAndWarnDisabled(@TempDir Path tempDir) throws Exception {
+        when(log.isWarnEnabled()).thenReturn(FALSE);
+        final Path basedir = createDirectory(tempDir.resolve("target")).toRealPath();
+        createFile(basedir.resolve("file"));
+        // Remove the writable flag to prevent deletion of the file, which will result in an AccessDeniedException.
+        final Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("r-xr-xr-x");
+        setPosixFilePermissions(basedir, permissions);
+        final Cleaner cleaner = new Cleaner(null, log, false, null, null);
+        assertDoesNotThrow(() -> cleaner.delete(basedir, null, false, false, false));
+        verify(log, never()).warn(any(CharSequence.class), any(Throwable.class));
+    }
+}


### PR DESCRIPTION
This is a PR for a merge of 3.x `maven-clean-plugin-3.x` to 4.x `master`. In particular, it includes the changes in the context of MCLEAN-110, MCLEAN-124, MCLEAN-126 and nothing else. There were some conflicts and differences between 3.x and 4.x, but I assumed they were intentional so I kept the 4.x behavior and adapted tests accordingly where needed. To preserve the nature of the merge commit, I strongly recommend merging this PR as a regular merge and _not_ a squash merge.