### PR TITLE
Configuration parameter for deleting read-only files

### DIFF
--- a/src/it/read-only/pom.xml
+++ b/src/it/read-only/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>test</groupId>
+  <artifactId>read-only</artifactId>
+  <version>1.0-SNAPSHOT</version>
+
+  <name>Test for clean</name>
+  <description>Check for proper deletion (or not) of read-only files.</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>@pom.version@</version>
+        <configuration>
+          <force>true</force>
+          <retryOnError>false</retryOnError>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/src/it/read-only/setup.bsh
+++ b/src/it/read-only/setup.bsh
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+
+if (!new File(basedir, "target/read-only-dir/read-only.properties").setWritable(false)) {
+    System.out.println("Cannot change file permission.");
+    return false;
+}
+if (File.separatorChar == '/') {
+    // Directory permission can be changed only on Unix, not on Windows.
+    if (!new File(basedir, "target/read-only-dir").setWritable(false)) {
+        System.out.println("Cannot change directory permission.");
+        return false;
+    }
+}
+if (!new File(basedir, "target/writable-dir/writable.properties").canWrite()) {
+    System.out.println("Expected a writable file.");
+    return false;
+}
+return true;

--- a/src/it/read-only/target/read-only-dir/read-only.properties
+++ b/src/it/read-only/target/read-only-dir/read-only.properties
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/src/it/read-only/target/writable-dir/writable.properties
+++ b/src/it/read-only/target/writable-dir/writable.properties
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/src/it/read-only/verify.bsh
+++ b/src/it/read-only/verify.bsh
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.File;
+
+if (new File(basedir, "target").exists()) {
+    System.out.println("target should have been deleted.");
+    return false;
+}
+return true;

--- a/src/main/java/org/apache/maven/plugins/clean/CleanMojo.java
+++ b/src/main/java/org/apache/maven/plugins/clean/CleanMojo.java
@@ -129,6 +129,14 @@ public class CleanMojo extends AbstractMojo {
     private boolean followSymLinks;
 
     /**
+     * Whether to force the deletion of read-only files.
+     *
+     * @since 3.4.2
+     */
+    @Parameter(property = "maven.clean.force", defaultValue = "false")
+    private boolean force;
+
+    /**
      * Disables the plugin execution. <br/>
      * Starting with <code>3.0.0</code> the property has been renamed from <code>clean.skip</code> to
      * <code>maven.clean.skip</code>.
@@ -249,7 +257,7 @@ public class CleanMojo extends AbstractMojo {
                     + FAST_MODE_BACKGROUND + "', '" + FAST_MODE_AT_END + "' and '" + FAST_MODE_DEFER + "'.");
         }
 
-        Cleaner cleaner = new Cleaner(session, getLog(), isVerbose(), fastDir, fastMode);
+        Cleaner cleaner = new Cleaner(session, getLog(), isVerbose(), fastDir, fastMode, force);
 
         try {
             for (Path directoryItem : getDirectories()) {

--- a/src/test/java/org/apache/maven/plugins/clean/CleanMojoTest.java
+++ b/src/test/java/org/apache/maven/plugins/clean/CleanMojoTest.java
@@ -250,7 +250,7 @@ class CleanMojoTest {
 
     private void testSymlink(LinkCreator linkCreator) throws Exception {
         // We use the SystemStreamLog() as the AbstractMojo class, because from there the Log is always provided
-        Cleaner cleaner = new Cleaner(null, new SystemStreamLog(), false, null, null);
+        Cleaner cleaner = new Cleaner(null, new SystemStreamLog(), false, null, null, false);
         Path testDir = Paths.get("target/test-classes/unit/test-dir").toAbsolutePath();
         Path dirWithLnk = testDir.resolve("dir");
         Path orgDir = testDir.resolve("org-dir");

--- a/src/test/java/org/apache/maven/plugins/clean/CleanerTest.java
+++ b/src/test/java/org/apache/maven/plugins/clean/CleanerTest.java
@@ -61,7 +61,7 @@ class CleanerTest {
     void deleteSucceedsDeeply(@TempDir Path tempDir) throws Exception {
         final Path basedir = createDirectory(tempDir.resolve("target")).toRealPath();
         final Path file = createFile(basedir.resolve("file"));
-        final Cleaner cleaner = new Cleaner(null, log, false, null, null);
+        final Cleaner cleaner = new Cleaner(null, log, false, null, null, false);
         cleaner.delete(basedir, null, false, true, false);
         assertFalse(exists(basedir));
         assertFalse(exists(file));
@@ -76,7 +76,7 @@ class CleanerTest {
         // Remove the executable flag to prevent directory listing, which will result in a DirectoryNotEmptyException.
         final Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("rw-rw-r--");
         setPosixFilePermissions(basedir, permissions);
-        final Cleaner cleaner = new Cleaner(null, log, false, null, null);
+        final Cleaner cleaner = new Cleaner(null, log, false, null, null, false);
         final IOException exception =
                 assertThrows(IOException.class, () -> cleaner.delete(basedir, null, false, true, false));
         verify(log, never()).warn(any(CharSequence.class), any(Throwable.class));
@@ -94,7 +94,7 @@ class CleanerTest {
         // Remove the executable flag to prevent directory listing, which will result in a DirectoryNotEmptyException.
         final Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("rw-rw-r--");
         setPosixFilePermissions(basedir, permissions);
-        final Cleaner cleaner = new Cleaner(null, log, false, null, null);
+        final Cleaner cleaner = new Cleaner(null, log, false, null, null, false);
         final IOException exception =
                 assertThrows(IOException.class, () -> cleaner.delete(basedir, null, false, true, true));
         assertEquals("Failed to delete " + basedir, exception.getMessage());
@@ -112,7 +112,7 @@ class CleanerTest {
         // Remove the writable flag to prevent deletion of the file, which will result in an AccessDeniedException.
         final Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("r-xr-xr-x");
         setPosixFilePermissions(basedir, permissions);
-        final Cleaner cleaner = new Cleaner(null, log, false, null, null);
+        final Cleaner cleaner = new Cleaner(null, log, false, null, null, false);
         assertDoesNotThrow(() -> cleaner.delete(basedir, null, false, false, false));
         verify(log, times(2)).warn(any(CharSequence.class), any(Throwable.class));
         InOrder inOrder = inOrder(log);
@@ -133,7 +133,7 @@ class CleanerTest {
         // Remove the writable flag to prevent deletion of the file, which will result in an AccessDeniedException.
         final Set<PosixFilePermission> permissions = PosixFilePermissions.fromString("r-xr-xr-x");
         setPosixFilePermissions(basedir, permissions);
-        final Cleaner cleaner = new Cleaner(null, log, false, null, null);
+        final Cleaner cleaner = new Cleaner(null, log, false, null, null, false);
         assertDoesNotThrow(() -> cleaner.delete(basedir, null, false, false, false));
         verify(log, never()).warn(any(CharSequence.class), any(Throwable.class));
     }


### PR DESCRIPTION
This is a port of #250 (add a`force` option), but trying to minimizing changes in the 3.x code base. In particular, this pull request does not include the migration to `java.nio.file.PathMatcher` (Plexus continues to be used) and to `java.nio.file.FileVisitor`, and does not change anything to log messages and exceptions.